### PR TITLE
Add connectionGetLine or similar

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -149,7 +149,7 @@ connectionGetChunk' conn f = withBuffer getData conn
               return $ swap $ f buf
 
         getMoreData (ConnectionTLS tlsctx) = TLS.recvData tlsctx
-        getMoreData (ConnectionStream h)   = hWaitForInput h (-1) >> B.hGetNonBlocking h (16 * 1024)
+        getMoreData (ConnectionStream h)   = B.hGetSome h (16 * 1024)
 
         swap (a, b) = (b, a)
 


### PR DESCRIPTION
Per your [suggestion on Reddit](http://www.reddit.com/r/haskell/comments/14vwvs/smtpemail_package_makes_sending_email_a_oneliner/c7h1br4), I plan to use the connection package for smtp-mail.  The implementation receives responses a line at a time.  It'd be more convenient and efficient if I could take advantage of the buffering that the connection package already does, rather than do my own buffering, to take only one line and save the leftovers.

To this end, I propose adding something like this:

```
connectionGetChunk' :: Connection -> (ByteString -> (a, ByteString)) -> IO a
```

The caller returns the part of the chunk it didn't use, so it will be the next data read.  If there wasn't enough data, the caller has to call `connectionGetChunk'` again.

Also, while we're at it: why do we do this?

```
hWaitForInput h (-1) >> B.hGetNonBlocking h (16 * 1024)
```

`hWaitForInput` can't be interrupted with an async exception under the threaded RTS (meaning [System.Timeout](http://hackage.haskell.org/packages/archive/base/latest/doc/html/System-Timeout.html) won't work).  Under the hood, it uses a plain `select()` call, rather than taking advantage of the system's scalable polling facility (where available).
