### PR TITLE
Connection to ECDSA-capable servers

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -14,7 +14,7 @@ module Network.Connection
     (
     -- * Type for a connection
       Connection
-    , connectionID
+    , ConnectionID
     , ConnectionParams(..)
     , TLSSettings(..)
     , ProxySettings(..)
@@ -34,6 +34,9 @@ module Network.Connection
     , connectFromSocket
     , connectTo
     , connectionClose
+
+    -- * Connection information
+    , connectionID
 
     -- * Sending and receiving data
     , connectionGet

--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -136,8 +136,7 @@ defaultClientParams cg cid =
             , (TLS.HashSHA224, TLS.SignatureRSA)
             , (TLS.HashSHA1,   TLS.SignatureRSA)
             , (TLS.HashSHA1,   TLS.SignatureDSS)
-            , (TLS.HashSHA512, TLS.SignatureECDSA)
-            , (TLS.HashSHA384, TLS.SignatureECDSA)
+            -- ECDSA + SEC_p256r1 + SHA-384/512 need cryptonite >= 0.20
             , (TLS.HashSHA256, TLS.SignatureECDSA)
             , (TLS.HashSHA224, TLS.SignatureECDSA)
             , (TLS.HashSHA1,   TLS.SignatureECDSA)

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -79,6 +79,7 @@ data TLSSettings
 instance Default TLSSettings where
     def = TLSSettingsSimple False False True
 
+-- | Connection destination.
 type ConnectionID = (HostName, PortNumber)
 
 -- | This opaque type represent a connection to a destination.

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -73,8 +73,25 @@ data TLSSettings
                                                            --   Not Implemented Yet.
              , settingUseServerName                :: Bool -- ^ Use server name extension. Not Implemented Yet.
              } -- ^ Simple TLS settings. recommended to use.
+    | TLSSettingsLambda (ConnectionContext -> ConnectionID -> TLS.ClientParams)
+               -- ^ Gives control to TLS Settings used for each connection.
+               --
+               -- Allows to override the defaults returned by
+               -- 'Network.Connection.defaultClientParams'.
     | TLSSettings TLS.ClientParams -- ^ full blown TLS Settings directly using TLS.Params. for power users.
-    deriving (Show)
+
+instance Show TLSSettings where
+    showsPrec d (TLSSettingsSimple dcv ds usn) =
+        showParen (d >= 11) $
+            showString "TLSSettingsSimple {"
+              . showString "settingDisableCertificateValidation = " . shows dcv . showString ", "
+              . showString "settingDisableSession = " . shows ds . showString ", "
+              . showString "settingUseServerName = " . shows usn
+              . showString "}"
+    showsPrec d (TLSSettingsLambda _) =
+        showParen (d >= 11) $ showString "TLSSettingsLambda <function>"
+    showsPrec d (TLSSettings clientParams) =
+        showParen (d >= 11) $ showString "TLSSettings " . showsPrec 11 clientParams
 
 instance Default TLSSettings where
     def = TLSSettingsSimple False False True

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -77,7 +77,7 @@ data TLSSettings
     deriving (Show)
 
 instance Default TLSSettings where
-    def = TLSSettingsSimple False False False
+    def = TLSSettingsSimple False False True
 
 type ConnectionID = (HostName, PortNumber)
 

--- a/examples/SMTPConnection.hs
+++ b/examples/SMTPConnection.hs
@@ -2,7 +2,7 @@
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 import Network.Connection
-import Data.Default
+import Data.Default.Class
 
 readHeader con = do
     l <- connectionGetLine 1024 con

--- a/examples/StartTLSConnection.hs
+++ b/examples/StartTLSConnection.hs
@@ -2,7 +2,7 @@
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 import Network.Connection
-import Data.Default
+import Data.Default.Class
 
 main = do
     ctx <- initConnectionContext

--- a/examples/TLSConnection.hs
+++ b/examples/TLSConnection.hs
@@ -1,6 +1,6 @@
 import qualified Data.ByteString as B
 import Network.Connection
-import Data.Default
+import Data.Default.Class
 
 main = do
     ctx <- initConnectionContext

--- a/examples/TLSCustom.hs
+++ b/examples/TLSCustom.hs
@@ -1,0 +1,34 @@
+import qualified Data.ByteString as B
+import Network.Connection
+import Network.TLS
+import Data.Default.Class
+
+-- example for TLSSettingsSimple (disable validation of server certificate)
+settingsNoCertValidation =
+    TLSSettingsSimple { settingDisableCertificateValidation = True
+                      , settingDisableSession = False
+                      , settingUseServerName = True
+                      }
+
+-- example for TLSSettingsLambda (disable TLS 1.2)
+settingsNoTLS12 =
+    TLSSettingsLambda $ \cg cid -> overrideParams (defaultClientParams cg cid)
+  where
+    overrideParams p =
+        p { clientSupported = overrideSupported (clientSupported p) }
+    overrideSupported s =
+        s { supportedVersions = [TLS10, TLS11] -- TLS12 removed
+          }
+
+main = do
+    ctx <- initConnectionContext
+    con <- connectTo ctx $ ConnectionParams
+                              { connectionHostname  = "www.example.com"
+                              , connectionPort      = 4567
+                              , connectionUseSecure = Just settingsNoTLS12
+                              , connectionUseSocks  = Nothing
+                              }
+    connectionPut con (B.singleton 0xa)
+    r <- connectionGet con 1024
+    putStrLn $ show r
+    connectionClose con


### PR DESCRIPTION
`cipher_ECDHE_ECDSA_AES128GCM_SHA256` is in `ciphersuite_all` and some servers,
most notably Google, try to choose this cipher but then abort when ECDSA
client-support is disabled (vincenthz/hs-tls#152).

So a way forward could be to enable ECDSA on the client side, but at the same
time provide a mechanism to control TLS ClientParams more easily, as suggested
in #20.  With this, people who do not like the change can revert to the
previous set of algorithms.

ECDSA support would be active by default in order by to fix
snoyberg/http-client#236.  But using `defaultClientParams` and the new
`TLSSettings` constructor then one can disable ECDSA like this for example:

```haskell
module Main ( main ) where

import Data.Default.Class ( def )

import Network.Connection ( TLSSettings(..), defaultClientParams )
import Network.HTTP.Conduit
import Network.TLS
import Network.TLS.Extra ( ciphersuite_all )

ecdsaDisabled :: TLSSettings
ecdsaDisabled =
    TLSSettingsLambda $ \cg cid -> overrideParams (defaultClientParams cg cid)
  where
    overrideParams params = params { clientSupported = supported }
    supported = def { supportedCiphers = ciphersuite_all } -- restore defaults

main :: IO ()
main = do
    let (Just req) = parseUrl "https://docs.google.com"

    mgrE <- newManager tlsManagerSettings
    httpLbs req mgrE >>= print -- handshake now succeeds

    mgrD <- newManager $ mkManagerSettings ecdsaDisabled Nothing
    httpLbs req mgrD >>= print -- InternalException (HandshakeFailed Error_EOF)
```
