### PR TITLE
Allow creation of custom context

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -27,7 +27,7 @@ module Network.Connection
 
     -- * Library initialization
     , initConnectionContext
-    , ConnectionContext
+    , ConnectionContext(..)
 
     -- * Connection operation
     , connectFromHandle


### PR DESCRIPTION
I wanted to have a play with getting it to connect to a toy cert chain, but without this being exposed was unable to do so without adding the certs to the system store.

I could well have missed something, if so let me know.

Thanks.