### PR TITLE
Add connectionUseAddress

### DIFF
--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -37,9 +37,10 @@ data ConnectionBackend = ConnectionStream Handle
 -- If you need to connect through a SOCKS, you should make sure
 -- connectionUseSocks is correctly set.
 data ConnectionParams = ConnectionParams
-    { connectionHostname   :: HostName           -- ^ host name to connect to.
-    , connectionPort       :: PortNumber         -- ^ port number to connect to.
-    , connectionUseSecure  :: Maybe TLSSettings  -- ^ optional TLS parameters.
+    { connectionHostname   :: HostName            -- ^ host name to connect to.
+    , connectionPort       :: PortNumber          -- ^ port number to connect to.
+    , connectionUseAddress :: Maybe String        -- ^ optional use specific IP.
+    , connectionUseSecure  :: Maybe TLSSettings   -- ^ optional TLS parameters.
     , connectionUseSocks   :: Maybe ProxySettings -- ^ optional Proxy/Socks configuration.
     }
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ byte, receive a single byte, print it, and close the connection:
     main = do
         ctx <- initConnectionContext
         con <- connectTo ctx $ ConnectionParams
-                                  { connectionHostname  = "www.example.com"
-                                  , connectionPort      = 4567
-                                  , connectionUseSecure = Nothing
-                                  , connectionUseSocks  = Nothing
+                                  { connectionHostname   = "www.example.com"
+                                  , connectionPort       = 4567
+                                  , connectionUseAddress = Nothing
+                                  , connectionUseSecure  = Nothing
+                                  , connectionUseSocks   = Nothing
                                   }
         connectionPut con (B.singleton 0xa)
         r <- connectionGet con 1
@@ -37,19 +38,21 @@ parameter, for example connecting to the same host, but using a socks
 proxy at localhost:1080:
 
     con <- connectTo ctx $ ConnectionParams
-                           { connectionHostname  = "www.example.com"
-                           , connectionPort      = 4567
-                           , connectionUseSecure = Nothing
-                           , connectionUseSocks  = Just $ SockSettingsSimple "localhost" 1080
+                           { connectionHostname   = "www.example.com"
+                           , connectionPort       = 4567
+                           , connectionUseAddress = Nothing
+                           , connectionUseSecure  = Nothing
+                           , connectionUseSocks   = Just $ SockSettingsSimple "localhost" 1080
                            }
 
 Connecting to a SSL style socket is equally easy, and need to set the UseSecure fields in ConnectionParams:
 
     con <- connectTo ctx $ ConnectionParams
-                           { connectionHostname  = "www.example.com"
-                           , connectionPort      = 4567
-                           , connectionUseSecure = Just def
-                           , connectionUseSocks  = Nothing
+                           { connectionHostname   = "www.example.com"
+                           , connectionPort       = 4567
+                           , connectionUseAddress = Nothing
+                           , connectionUseSecure  = Just def
+                           , connectionUseSocks   = Nothing
                            }
 
 And finally, you can start TLS in the middle of an insecure connection. This is great for
@@ -64,10 +67,11 @@ protocol using STARTTLS (e.g. IMAP, SMTP):
     main = do
         ctx <- initConnectionContext
         con <- connectTo ctx $ ConnectionParams
-                                  { connectionHostname  = "www.example.com"
-                                  , connectionPort      = 4567
-                                  , connectionUseSecure = Nothing
-                                  , connectionUseSocks  = Nothing
+                                  { connectionHostname   = "www.example.com"
+                                  , connectionPort       = 4567
+                                  , connectionUseAddress = Nothing
+                                  , connectionUseSecure  = Nothing
+                                  , connectionUseSocks   = Nothing
                                   }
         -- talk to the other side with no TLS: says hello and starttls
         connectionPut con "HELLO\n"

--- a/examples/SMTPConnection.hs
+++ b/examples/SMTPConnection.hs
@@ -8,16 +8,17 @@ readHeader con = do
     l <- connectionGetLine 1024 con
     putStrLn $ show l
     if B.isPrefixOf "250 " l
-        then return ()  
+        then return ()
         else readHeader con
-        
+
 main = do
     ctx <- initConnectionContext
     con <- connectTo ctx $ ConnectionParams
-                            { connectionHostname  = "my.smtp.server"
-                            , connectionPort      = 25
-                            , connectionUseSecure = Nothing
-                            , connectionUseSocks  = Nothing
+                            { connectionHostname   = "my.smtp.server"
+                            , connectionPort       = 25
+                            , connectionUseAddress = Nothing
+                            , connectionUseSecure  = Nothing
+                            , connectionUseSocks   = Nothing
                             }
 
     -- | read the server banner

--- a/examples/SimpleConnection.hs
+++ b/examples/SimpleConnection.hs
@@ -4,10 +4,11 @@ import Network.Connection
 main = do
     ctx <- initConnectionContext
     con <- connectTo ctx $ ConnectionParams
-                              { connectionHostname  = "www.example.com"
-                              , connectionPort      = 4567
-                              , connectionUseSecure = Nothing
-                              , connectionUseSocks  = Nothing
+                              { connectionHostname   = "www.example.com"
+                              , connectionPort       = 4567
+                              , connectionUseAddress = Nothing
+                              , connectionUseSecure  = Nothing
+                              , connectionUseSocks   = Nothing
                               }
     connectionPut con (B.singleton 0xa)
     r <- connectionGet con 1024

--- a/examples/SocksConnection.hs
+++ b/examples/SocksConnection.hs
@@ -4,10 +4,11 @@ import Network.Connection
 main = do
     ctx <- initConnectionContext
     con <- connectTo ctx $ ConnectionParams
-                              { connectionHostname  = "www.example.com"
-                              , connectionPort      = 4567
-                              , connectionUseSecure = Nothing
-                              , connectionUseSocks  = Just $ SockSettingsSimple "localhost" 1080
+                              { connectionHostname   = "www.example.com"
+                              , connectionPort       = 4567
+                              , connectionUseAddress = Nothing
+                              , connectionUseSecure  = Nothing
+                              , connectionUseSocks   = Just $ SockSettingsSimple "localhost" 1080
                               }
     connectionPut con (B.singleton 0xa)
     r <- connectionGet con 1024

--- a/examples/StartTLSConnection.hs
+++ b/examples/StartTLSConnection.hs
@@ -7,18 +7,19 @@ import Data.Default
 main = do
     ctx <- initConnectionContext
     con <- connectTo ctx $ ConnectionParams
-                              { connectionHostname  = "www.example.com"
-                              , connectionPort      = 4567
-                              , connectionUseSecure = Nothing
-                              , connectionUseSocks  = Nothing
+                              { connectionHostname   = "www.example.com"
+                              , connectionPort       = 4567
+                              , connectionUseAddress = Nothing
+                              , connectionUseSecure  = Nothing
+                              , connectionUseSocks   = Nothing
                               }
-    -- talk to the other side, says hello and starttls 
+    -- talk to the other side, says hello and starttls
     connectionPut con "HELLO\n"
     connectionPut con "STARTTLS\n"
 
     -- switch to TLS
     connectionSetSecure ctx con def
 
-    -- the connection is now on using TLS, we can send secret for examplek
+    -- the connection is now on using TLS, we can send secret for example
     connectionPut con "PASSWORD 123\n"
     connectionClose con

--- a/examples/TLSConnection.hs
+++ b/examples/TLSConnection.hs
@@ -5,10 +5,11 @@ import Data.Default
 main = do
     ctx <- initConnectionContext
     con <- connectTo ctx $ ConnectionParams
-                              { connectionHostname  = "www.example.com"
-                              , connectionPort      = 4567
-                              , connectionUseSecure = Just def
-                              , connectionUseSocks  = Nothing
+                              { connectionHostname   = "www.example.com"
+                              , connectionPort       = 4567
+                              , connectionUseAddress = Nothing
+                              , connectionUseSecure  = Just def
+                              , connectionUseSocks   = Nothing
                               }
     connectionPut con (B.singleton 0xa)
     r <- connectionGet con 1024


### PR DESCRIPTION
This adds ```connectionUseAddress``` to ```ConnectionParams```, ```connectTo``` is modified to take advantage of the new field. The hostname is correctly used for TLS while ```connectionUseAddress``` is used for the connection if provided. The calls to ```socksConnectTo'``` will also use the provided address for the destination (not the proxy).

This functionality can be expressed manually by setting up your own connection and using ```connectFromSocket```. Having a way to do this directly in the API is more convenient particularly when this library is used in higher level packages. The ```SocksSettings``` could also be done manually through ```connectFromSocket``` and ```socksConnectTo'```.

If you want I could modify this to use a wrapper around ```HostAddress``` and ```HostAddress6``` from ```Network.Socket``` if the use of String bothers you. Unfortunately they do not just provide a sum type for IPv4 or IPv6.
