### PR TITLE
Fix TLS settings

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -56,7 +56,6 @@ import qualified Control.Exception as E
 import qualified System.IO.Error as E (mkIOError, eofErrorType)
 
 import qualified Network.TLS as TLS
-import qualified Network.TLS.Extra as TLS
 
 import System.X509 (getSystemCertificateStore)
 
@@ -114,7 +113,7 @@ initConnectionContext = ConnectionContext <$> getSystemCertificateStore
 makeTLSParams :: ConnectionContext -> ConnectionID -> TLSSettings -> TLS.ClientParams
 makeTLSParams cg cid ts@(TLSSettingsSimple {}) =
     (TLS.defaultParamsClient (fst cid) portString)
-        { TLS.clientSupported = def { TLS.supportedCiphers = TLS.ciphersuite_all }
+        { TLS.clientSupported = def { TLS.supportedCiphers = settingsSupportedCiphers ts }
         , TLS.clientShared    = def
             { TLS.sharedCAStore         = globalCertificateStore cg
             , TLS.sharedValidationCache = validationCache

--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -113,7 +113,7 @@ initConnectionContext = ConnectionContext <$> getSystemCertificateStore
 makeTLSParams :: ConnectionContext -> ConnectionID -> TLSSettings -> TLS.ClientParams
 makeTLSParams cg cid ts@(TLSSettingsSimple {}) =
     (TLS.defaultParamsClient (fst cid) portString)
-        { TLS.clientSupported = def { TLS.supportedCiphers = settingsSupportedCiphers ts }
+        { TLS.clientSupported = def { TLS.supportedCiphers = settingSupportedCiphers ts }
         , TLS.clientShared    = def
             { TLS.sharedCAStore         = globalCertificateStore cg
             , TLS.sharedValidationCache = validationCache
@@ -204,7 +204,7 @@ connectTo cg cParams = do
             let serv = case portid of
                             N.Service serv -> serv
                             N.PortNumber n -> show n
-                            _              -> error "cannot resolve service" 
+                            _              -> error "cannot resolve service"
             proto <- getProtocolNumber "tcp"
             let hints = defaultHints { addrFlags = [AI_ADDRCONFIG]
                                      , addrProtocol = proto

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -81,7 +81,7 @@ data TLSSettings
     deriving (Show)
 
 instance Default TLSSettings where
-    def = TLSSettingsSimple False TLS.ciphersuite_all False False
+    def = TLSSettingsSimple False TLS.ciphersuite_default False False
 
 type ConnectionID = (HostName, PortNumber)
 

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -19,6 +19,7 @@ import Data.ByteString (ByteString)
 import Network.BSD (HostName)
 import Network.Socket (PortNumber, Socket)
 import qualified Network.TLS as TLS
+import qualified Network.TLS.Extra.Cipher as TLS
 
 import System.IO (Handle)
 
@@ -68,6 +69,9 @@ data TLSSettings
              { settingDisableCertificateValidation :: Bool -- ^ Disable certificate verification completely,
                                                            --   this make TLS/SSL vulnerable to a MITM attack.
                                                            --   not recommended to use, but for testing.
+             , settingsSupportedCiphers            :: [TLS.Cipher]
+                                                           -- ^ Default 'False'.  If this is 'True', client
+                                                           --   allows old and unsafe crypto algorithms.
              , settingDisableSession               :: Bool -- ^ Disable session management. TLS/SSL connections
                                                            --   will always re-established their context.
                                                            --   Not Implemented Yet.
@@ -77,7 +81,7 @@ data TLSSettings
     deriving (Show)
 
 instance Default TLSSettings where
-    def = TLSSettingsSimple False False False
+    def = TLSSettingsSimple False TLS.ciphersuite_all False False
 
 type ConnectionID = (HostName, PortNumber)
 

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -69,7 +69,7 @@ data TLSSettings
              { settingDisableCertificateValidation :: Bool -- ^ Disable certificate verification completely,
                                                            --   this make TLS/SSL vulnerable to a MITM attack.
                                                            --   not recommended to use, but for testing.
-             , settingsSupportedCiphers            :: [TLS.Cipher]
+             , settingSupportedCiphers             :: [TLS.Cipher]
                                                            -- ^ Default 'False'.  If this is 'True', client
                                                            --   allows old and unsafe crypto algorithms.
              , settingDisableSession               :: Bool -- ^ Disable session management. TLS/SSL connections

--- a/connection.cabal
+++ b/connection.cabal
@@ -1,5 +1,5 @@
 Name:                connection
-Version:             0.2.8
+Version:             0.3.0
 Description:
     Simple network library for all your connection need.
     .


### PR DESCRIPTION
Currently, the *default* ciphersuite for TLS connections is not `ciphersuite_default`, but `ciphersuite_all`.  This is not only surprising, but also insecure and rarely what you want.

This PR fixes this.  It is a breaking change, but I think it should be.  If you disagree, I would be almost as happy to change this PR to just make `ciphersuite_default` the default, and leave all the types unchanged.  This way library users would get their systems fixed without having to do anything, but it would also make it harder for them to find out what's wrong if they really need `ciphersuite_all`.

Otherwise a happy user!  Thanks for writing this.  :-)