### PR TITLE
Add constructor taking a ciphersuite field to `TLSSettings`.

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -116,7 +116,7 @@ makeTLSParams cg cid (TLSSettingsSimple v s n) =
   makeTLSParams cg cid (TLSSettingsSimpleWithCiphers v TLS.ciphersuite_default s n)
 makeTLSParams cg cid ts@(TLSSettingsSimpleWithCiphers {}) =
     (TLS.defaultParamsClient (fst cid) portString)
-        { TLS.clientSupported = def { TLS.supportedCiphers = settingsSupportedCiphers ts }
+        { TLS.clientSupported = def { TLS.supportedCiphers = settingSupportedCiphers ts }
         , TLS.clientShared    = def
             { TLS.sharedCAStore         = globalCertificateStore cg
             , TLS.sharedValidationCache = validationCache

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -19,6 +19,7 @@ import Data.ByteString (ByteString)
 import Network.BSD (HostName)
 import Network.Socket (PortNumber, Socket)
 import qualified Network.TLS as TLS
+import qualified Network.TLS.Extra.Cipher as TLS
 
 import System.IO (Handle)
 
@@ -68,6 +69,18 @@ data TLSSettings
              { settingDisableCertificateValidation :: Bool -- ^ Disable certificate verification completely,
                                                            --   this make TLS/SSL vulnerable to a MITM attack.
                                                            --   not recommended to use, but for testing.
+             , settingDisableSession               :: Bool -- ^ Disable session management. TLS/SSL connections
+                                                           --   will always re-established their context.
+                                                           --   Not Implemented Yet.
+             , settingUseServerName                :: Bool -- ^ Use server name extension. Not Implemented Yet.
+             } -- ^ Simple TLS settings. recommended to use.
+    | TLSSettingsSimpleWithCiphers
+             { settingDisableCertificateValidation :: Bool -- ^ Disable certificate verification completely,
+                                                           --   this make TLS/SSL vulnerable to a MITM attack.
+                                                           --   not recommended to use, but for testing.
+             , settingsSupportedCiphers            :: [TLS.Cipher]
+                                                           -- ^ Default 'False'.  If this is 'True', client
+                                                           --   allows old and unsafe crypto algorithms.
              , settingDisableSession               :: Bool -- ^ Disable session management. TLS/SSL connections
                                                            --   will always re-established their context.
                                                            --   Not Implemented Yet.

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -78,7 +78,7 @@ data TLSSettings
              { settingDisableCertificateValidation :: Bool -- ^ Disable certificate verification completely,
                                                            --   this make TLS/SSL vulnerable to a MITM attack.
                                                            --   not recommended to use, but for testing.
-             , settingsSupportedCiphers            :: [TLS.Cipher]
+             , settingSupportedCiphers             :: [TLS.Cipher]
                                                            -- ^ Default 'False'.  If this is 'True', client
                                                            --   allows old and unsafe crypto algorithms.
              , settingDisableSession               :: Bool -- ^ Disable session management. TLS/SSL connections


### PR DESCRIPTION
More downwards-compatible variant of #34.

If I now change the default back from `default` to `all`, the change will have no impact whatsoever on existing code.  (I'm still in favor of making `default` the default, though. :-) )