### PR TITLE
Socks5 authentication

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -221,15 +221,14 @@ connectTo cg cParams = do
                 return (sHost, sPort, Nothing)
             (sUsernamePassword, '@':sHostPort) -> do
                 (sHost, sPort) <- parseSocksHostPort sHostPort
-                return (sHost, sPort, (parseSocksUserNamePassword sUsernamePassword))
+                return (sHost, sPort, Just (parseSocksUserNamePassword sUsernamePassword))
             _                                  -> Nothing
 
     -- Try to parse "username:password"
     -- password can be an empty string, "username:" and "username" produce the same result
-    parseSocksUserNamePassword :: String -> Maybe(SocksAuthUsername)
-    parseSocksUserNamePassword s =
-        case break (== ':') s of
-            (sUsername, sPassword) -> Just (SocksAuthUsername (BC.pack sUsername) (BC.pack sPassword))
+    parseSocksUserNamePassword :: String -> SocksAuthUsername
+    parseSocksUserNamePassword s = SocksAuthUsername (BC.pack sUsername) (BC.pack sPassword)
+        where (sUsername, sPassword) = break (== ':') s
 
     -- Try to parse "host:port" or "host"
     -- if port is ommited then the default SOCKS port (1080) is assumed

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -53,8 +53,7 @@ data ConnectionParams = ConnectionParams
 --
 -- The simple SOCKS settings is just the hostname and portnumber of the SOCKS proxy server.
 --
--- That's for now the only settings in the SOCKS package,
--- socks password, or any sort of other authentications is not yet implemented.
+-- The auth SOCKS settings also contains username and password
 data ProxySettings =
       SockSettingsSimple HostName PortNumber
     | SockSettingsAuth HostName PortNumber Socks5.SocksAuthUsername

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -18,6 +18,7 @@ import Data.ByteString (ByteString)
 
 import Network.Socket (PortNumber, Socket)
 import qualified Network.TLS as TLS
+import qualified Network.Socks5 as Socks5
 
 import System.IO (Handle)
 
@@ -56,6 +57,7 @@ data ConnectionParams = ConnectionParams
 -- socks password, or any sort of other authentications is not yet implemented.
 data ProxySettings =
       SockSettingsSimple HostName PortNumber
+    | SockSettingsAuth HostName PortNumber Socks5.SocksAuthUsername
     | SockSettingsEnvironment (Maybe String)
     | OtherProxy HostName PortNumber
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,18 @@ proxy at localhost:1080:
                            { connectionHostname  = "www.example.com"
                            , connectionPort      = 4567
                            , connectionUseSecure = Nothing
-                           , connectionUseSocks  = Just $ SockSettingsSimple "localhost" 1080
+                           , connectionUseSocks  = Just $ SockSettingsSimple "localhost" 1080 
+                           }
+
+Socks5 username authentication is also supported:
+
+    import qualified Network.Socks5 as Socks5
+
+    con <- connectTo ctx $ ConnectionParams
+                           { connectionHostname  = "www.example.com"
+                           , connectionPort      = 4567
+                           , connectionUseSecure = Nothing
+                           , connectionUseSocks  = Just $ SockSettingsAuth localhost" 1080 (Socks5.SocksAuthUsername "username" "password")
                            }
 
 Connecting to a SSL style socket is equally easy, and need to set the UseSecure fields in ConnectionParams:


### PR DESCRIPTION
It depends on this PR: https://github.com/vincenthz/hs-socks/pull/24

I'm not sure about exposing `Socks5.SocksAuthUsername` type, but it seems more logical than another wrapper which would have the same exact fields.