### PR TITLE
Update network bound to fix #39

### DIFF
--- a/connection.cabal
+++ b/connection.cabal
@@ -27,7 +27,7 @@ Library
                    , bytestring
                    , containers
                    , data-default-class
-                   , network >= 2.6
+                   , network >= 2.6.3
                    , tls >= 1.4
                    , socks >= 0.6
                    , x509 >= 1.5


### PR DESCRIPTION
Read instance for PortNumber was only added in 2.6.3 resulting in
https://github.com/vincenthz/hs-connection/issues/39