### PR TITLE
Remove AI_ADDRCONFIG flag from getAddrInfo hints

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -226,7 +226,7 @@ connectTo cg cParams = do
     -- succeed
     resolve' :: String -> PortNumber -> IO (Socket, SockAddr)
     resolve' host port = do
-        let hints = defaultHints { addrFlags = [AI_ADDRCONFIG], addrSocketType = Stream }
+        let hints = defaultHints { addrSocketType = Stream }
         addrs <- getAddrInfo (Just hints) (Just host) (Just $ show port)
         firstSuccessful $ map tryToConnect addrs
       where


### PR DESCRIPTION
Do not use AI_ADDRCONFIG flag in getAddrInfo hints as it cannot handle '127.0.0.1' on IPv6-only machines.