### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/connection.cabal
+++ b/connection.cabal
@@ -16,7 +16,7 @@ Synopsis:            Simple and easy network connections API
 Build-Type:          Simple
 Category:            Network
 stability:           experimental
-Cabal-Version:       >=1.6
+Cabal-Version:       >=1.8
 Homepage:            https://github.com/vincenthz/hs-connection
 extra-source-files:  README.md
                      CHANGELOG.md


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: connection.cabal:25:34: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```