### PR TITLE
Asynchronous search for successful IP

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -51,6 +51,9 @@ module Network.Connection
     , connectionSessionManager
     ) where
 
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (withAsync, waitCatch)
+import Control.Concurrent.STM
 import Control.Concurrent.MVar
 import Control.Monad (join)
 import qualified Control.Exception as E

--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -67,6 +67,7 @@ import Network.Socks5 (defaultSocksConf, socksConnectWithSocket, SocksAddress(..
 import Network.Socket
 import qualified Network.Socket.ByteString as N
 
+import Data.Tuple (swap)
 import Data.Default.Class
 import Data.Data
 import Data.ByteString (ByteString)

--- a/connection.cabal
+++ b/connection.cabal
@@ -29,7 +29,7 @@ Library
                    , containers
                    , data-default-class
                    , network >= 2.6.3
-                   , stm >= 2.4
+                   , stm >= 2.3
                    , tls >= 1.4
                    , socks >= 0.6
                    , x509 >= 1.5

--- a/connection.cabal
+++ b/connection.cabal
@@ -23,11 +23,13 @@ extra-source-files:  README.md
 
 Library
   Build-Depends:     base >= 3 && < 5
+                   , async
                    , basement
                    , bytestring
                    , containers
                    , data-default-class
                    , network >= 2.6.3
+                   , stm >= 2.4
                    , tls >= 1.4
                    , socks >= 0.6
                    , x509 >= 1.5


### PR DESCRIPTION
This is to introduce a minimal (and not complete) implementation of RFC 6555 and RFC 8305.

    Instead of doing manual asynchronous DNS lookup for AAAA and A records, it relies on getAddrInfo.
    Available IP addresses are chosen concurrently.

The reason for the change is to avoid long timeouts when a domain has AAAA DNS record but no IPv6 connectivity, which is a relatively common misconfiguration.